### PR TITLE
IAR-5354 Add the Location command to Core sample app

### DIFF
--- a/IAR-CoreSDK-Sample/IAR-CoreSDK-Sample.xcodeproj/project.pbxproj
+++ b/IAR-CoreSDK-Sample/IAR-CoreSDK-Sample.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0B5799610C512D5AA81B078D /* Pods_IAR_CoreSDK_Sample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52C3BE5BC0D528D82DC2EB33 /* Pods_IAR_CoreSDK_Sample.framework */; };
+		39C8FF54F9EFBAF3ED091E1C /* Pods_IAR_CoreSDK_Sample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DB43F84404BA2E68A6401FD /* Pods_IAR_CoreSDK_Sample.framework */; };
 		489C4ED22797184900EC30EC /* PreferencesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C4ED02797184900EC30EC /* PreferencesController.swift */; };
 		489C4ED32797184900EC30EC /* ExternalUsersController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C4ED12797184900EC30EC /* ExternalUsersController.swift */; };
 		489C4ED62797185D00EC30EC /* UIAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C4ED52797185D00EC30EC /* UIAlertController.swift */; };
@@ -21,8 +21,6 @@
 		48C299D4278364BB00780AD3 /* MainViewControllerSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C299D3278364BB00780AD3 /* MainViewControllerSpecs.swift */; };
 		48C299DE278364BB00780AD3 /* IAR_CoreSDK_SampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C299DD278364BB00780AD3 /* IAR_CoreSDK_SampleUITests.swift */; };
 		48C299E0278364BB00780AD3 /* IAR_CoreSDK_SampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48C299DF278364BB00780AD3 /* IAR_CoreSDK_SampleUITestsLaunchTests.swift */; };
-		4CD7924FF4290B54659AB73A /* Pods_IAR_CoreSDK_Sample_IAR_CoreSDK_SampleUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5EAB0C55DB9ADCFBC4F4CA1D /* Pods_IAR_CoreSDK_Sample_IAR_CoreSDK_SampleUITests.framework */; };
-		7AC14407393A01947C64A0A5 /* Pods_IAR_CoreSDK_SampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D72494209343D69B804FB728 /* Pods_IAR_CoreSDK_SampleTests.framework */; };
 		A30D9C9C279FA48100FE6410 /* PreviewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A30D9C9A279FA48100FE6410 /* PreviewCell.xib */; };
 		A30D9C9D279FA48100FE6410 /* PreviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30D9C9B279FA48100FE6410 /* PreviewCell.swift */; };
 		A30D9C9F279FACCF00FE6410 /* UIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30D9C9E279FACCF00FE6410 /* UIImageView.swift */; };
@@ -43,10 +41,13 @@
 		A3854BF42791791100B9E9C9 /* OnDemandMarkersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3854BF32791791100B9E9C9 /* OnDemandMarkersViewController.swift */; };
 		A396CBEC27A2F79800EF72CF /* UserRewardsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A396CBEB27A2F79800EF72CF /* UserRewardsViewController.swift */; };
 		A396CBEE27A2F8B000EF72CF /* UserRewardDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A396CBED27A2F8B000EF72CF /* UserRewardDetailViewController.swift */; };
+		A3A3110A27C6929000930630 /* DebugLocationCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3A3110927C6929000930630 /* DebugLocationCommand.swift */; };
 		A3C2B0D827A2584900FE3A75 /* ARHuntDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3C2B0D727A2584900FE3A75 /* ARHuntDetailsViewController.swift */; };
 		A3DBB60827AD732400285E1E /* ARHuntMarkerDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DBB60727AD732400285E1E /* ARHuntMarkerDetailsViewController.swift */; };
 		A3DBB60A27AD734500285E1E /* ARHuntRewardDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DBB60927AD734500285E1E /* ARHuntRewardDetailsViewController.swift */; };
 		A3DBB60C27AD9C5B00285E1E /* LocationMarkersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DBB60B27AD9C5B00285E1E /* LocationMarkersViewController.swift */; };
+		A76F73A316E555FD1DAF5343 /* Pods_IAR_CoreSDK_Sample_IAR_CoreSDK_SampleUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F2FE9BF9B07C92F8A9B19B9A /* Pods_IAR_CoreSDK_Sample_IAR_CoreSDK_SampleUITests.framework */; };
+		E093AB05F07F6FE51DA503FB /* Pods_IAR_CoreSDK_SampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 965A81FD884F8BDF07FBBC24 /* Pods_IAR_CoreSDK_SampleTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +68,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1C8A7611BA37B5F08C04DDC3 /* Pods-IAR-CoreSDK-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-CoreSDK-Sample.debug.xcconfig"; path = "Target Support Files/Pods-IAR-CoreSDK-Sample/Pods-IAR-CoreSDK-Sample.debug.xcconfig"; sourceTree = "<group>"; };
+		2A6C06465D467A023EF5A644 /* Pods-IAR-CoreSDK-SampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-CoreSDK-SampleTests.release.xcconfig"; path = "Target Support Files/Pods-IAR-CoreSDK-SampleTests/Pods-IAR-CoreSDK-SampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		3DB43F84404BA2E68A6401FD /* Pods_IAR_CoreSDK_Sample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_CoreSDK_Sample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		489C4ED02797184900EC30EC /* PreferencesController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PreferencesController.swift; path = "../../../../IAR-Samples-Common/Controllers/PreferencesController.swift"; sourceTree = "<group>"; };
 		489C4ED12797184900EC30EC /* ExternalUsersController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExternalUsersController.swift; path = "../../../../IAR-Samples-Common/Controllers/ExternalUsersController.swift"; sourceTree = "<group>"; };
 		489C4ED52797185D00EC30EC /* UIAlertController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIAlertController.swift; path = "../../../../../IAR-Samples-Common/Extensions/UIKit/UIAlertController.swift"; sourceTree = "<group>"; };
@@ -80,13 +84,10 @@
 		48C299D9278364BB00780AD3 /* IAR-CoreSDK-SampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "IAR-CoreSDK-SampleUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		48C299DD278364BB00780AD3 /* IAR_CoreSDK_SampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAR_CoreSDK_SampleUITests.swift; sourceTree = "<group>"; };
 		48C299DF278364BB00780AD3 /* IAR_CoreSDK_SampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IAR_CoreSDK_SampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
-		52C3BE5BC0D528D82DC2EB33 /* Pods_IAR_CoreSDK_Sample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_CoreSDK_Sample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		57CFA1C7D84C09483696BE5E /* Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.debug.xcconfig"; path = "Target Support Files/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
-		5EAB0C55DB9ADCFBC4F4CA1D /* Pods_IAR_CoreSDK_Sample_IAR_CoreSDK_SampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_CoreSDK_Sample_IAR_CoreSDK_SampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		7883EBEC607823DA5E16F3B8 /* Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.release.xcconfig"; path = "Target Support Files/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.release.xcconfig"; sourceTree = "<group>"; };
-		8871C134A55B28B0A8EF7800 /* Pods-IAR-CoreSDK-SampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-CoreSDK-SampleTests.release.xcconfig"; path = "Target Support Files/Pods-IAR-CoreSDK-SampleTests/Pods-IAR-CoreSDK-SampleTests.release.xcconfig"; sourceTree = "<group>"; };
-		8EC3CF131ACB105DE435A41B /* Pods-IAR-CoreSDK-SampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-CoreSDK-SampleTests.debug.xcconfig"; path = "Target Support Files/Pods-IAR-CoreSDK-SampleTests/Pods-IAR-CoreSDK-SampleTests.debug.xcconfig"; sourceTree = "<group>"; };
-		973259A892C575D88AFDCB54 /* Pods-IAR-CoreSDK-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-CoreSDK-Sample.debug.xcconfig"; path = "Target Support Files/Pods-IAR-CoreSDK-Sample/Pods-IAR-CoreSDK-Sample.debug.xcconfig"; sourceTree = "<group>"; };
+		546C40EAA581B311326B0D84 /* Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.release.xcconfig"; path = "Target Support Files/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.release.xcconfig"; sourceTree = "<group>"; };
+		8D615D020FB89C206364F7B5 /* Pods-IAR-CoreSDK-SampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-CoreSDK-SampleTests.debug.xcconfig"; path = "Target Support Files/Pods-IAR-CoreSDK-SampleTests/Pods-IAR-CoreSDK-SampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		965A81FD884F8BDF07FBBC24 /* Pods_IAR_CoreSDK_SampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_CoreSDK_SampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9E5D1056BC628FE9B6235E1E /* Pods-IAR-CoreSDK-Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-CoreSDK-Sample.release.xcconfig"; path = "Target Support Files/Pods-IAR-CoreSDK-Sample/Pods-IAR-CoreSDK-Sample.release.xcconfig"; sourceTree = "<group>"; };
 		A30D9C9A279FA48100FE6410 /* PreviewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = PreviewCell.xib; sourceTree = "<group>"; };
 		A30D9C9B279FA48100FE6410 /* PreviewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreviewCell.swift; sourceTree = "<group>"; };
 		A30D9C9E279FACCF00FE6410 /* UIImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIImageView.swift; path = "../../../../../IAR-Samples-Common/Extensions/UIKit/UIImageView.swift"; sourceTree = "<group>"; };
@@ -107,12 +108,13 @@
 		A3854BF32791791100B9E9C9 /* OnDemandMarkersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnDemandMarkersViewController.swift; sourceTree = "<group>"; };
 		A396CBEB27A2F79800EF72CF /* UserRewardsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRewardsViewController.swift; sourceTree = "<group>"; };
 		A396CBED27A2F8B000EF72CF /* UserRewardDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRewardDetailViewController.swift; sourceTree = "<group>"; };
+		A3A3110927C6929000930630 /* DebugLocationCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DebugLocationCommand.swift; sourceTree = "<group>"; };
 		A3C2B0D727A2584900FE3A75 /* ARHuntDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARHuntDetailsViewController.swift; sourceTree = "<group>"; };
 		A3DBB60727AD732400285E1E /* ARHuntMarkerDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARHuntMarkerDetailsViewController.swift; sourceTree = "<group>"; };
 		A3DBB60927AD734500285E1E /* ARHuntRewardDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ARHuntRewardDetailsViewController.swift; sourceTree = "<group>"; };
 		A3DBB60B27AD9C5B00285E1E /* LocationMarkersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationMarkersViewController.swift; sourceTree = "<group>"; };
-		A683C13E29A5C6A581ACA482 /* Pods-IAR-CoreSDK-Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-CoreSDK-Sample.release.xcconfig"; path = "Target Support Files/Pods-IAR-CoreSDK-Sample/Pods-IAR-CoreSDK-Sample.release.xcconfig"; sourceTree = "<group>"; };
-		D72494209343D69B804FB728 /* Pods_IAR_CoreSDK_SampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_CoreSDK_SampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C93D56B0F9AC4A2AB9A12B34 /* Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.debug.xcconfig"; path = "Target Support Files/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		F2FE9BF9B07C92F8A9B19B9A /* Pods_IAR_CoreSDK_Sample_IAR_CoreSDK_SampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_CoreSDK_Sample_IAR_CoreSDK_SampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,7 +122,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0B5799610C512D5AA81B078D /* Pods_IAR_CoreSDK_Sample.framework in Frameworks */,
+				39C8FF54F9EFBAF3ED091E1C /* Pods_IAR_CoreSDK_Sample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -131,7 +133,7 @@
 				489C4EE727971BD900EC30EC /* SpecLeaks in Frameworks */,
 				489C4EE427971BC600EC30EC /* Quick in Frameworks */,
 				489C4EE127971BB000EC30EC /* Nimble in Frameworks */,
-				7AC14407393A01947C64A0A5 /* Pods_IAR_CoreSDK_SampleTests.framework in Frameworks */,
+				E093AB05F07F6FE51DA503FB /* Pods_IAR_CoreSDK_SampleTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -139,7 +141,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4CD7924FF4290B54659AB73A /* Pods_IAR_CoreSDK_Sample_IAR_CoreSDK_SampleUITests.framework in Frameworks */,
+				A76F73A316E555FD1DAF5343 /* Pods_IAR_CoreSDK_Sample_IAR_CoreSDK_SampleUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -149,24 +151,14 @@
 		13637614CA192FF5EB9216A0 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				973259A892C575D88AFDCB54 /* Pods-IAR-CoreSDK-Sample.debug.xcconfig */,
-				A683C13E29A5C6A581ACA482 /* Pods-IAR-CoreSDK-Sample.release.xcconfig */,
-				57CFA1C7D84C09483696BE5E /* Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.debug.xcconfig */,
-				7883EBEC607823DA5E16F3B8 /* Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.release.xcconfig */,
-				8EC3CF131ACB105DE435A41B /* Pods-IAR-CoreSDK-SampleTests.debug.xcconfig */,
-				8871C134A55B28B0A8EF7800 /* Pods-IAR-CoreSDK-SampleTests.release.xcconfig */,
+				1C8A7611BA37B5F08C04DDC3 /* Pods-IAR-CoreSDK-Sample.debug.xcconfig */,
+				9E5D1056BC628FE9B6235E1E /* Pods-IAR-CoreSDK-Sample.release.xcconfig */,
+				C93D56B0F9AC4A2AB9A12B34 /* Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.debug.xcconfig */,
+				546C40EAA581B311326B0D84 /* Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.release.xcconfig */,
+				8D615D020FB89C206364F7B5 /* Pods-IAR-CoreSDK-SampleTests.debug.xcconfig */,
+				2A6C06465D467A023EF5A644 /* Pods-IAR-CoreSDK-SampleTests.release.xcconfig */,
 			);
 			path = Pods;
-			sourceTree = "<group>";
-		};
-		264AEA2C93A96AFB09C8F942 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				52C3BE5BC0D528D82DC2EB33 /* Pods_IAR_CoreSDK_Sample.framework */,
-				5EAB0C55DB9ADCFBC4F4CA1D /* Pods_IAR_CoreSDK_Sample_IAR_CoreSDK_SampleUITests.framework */,
-				D72494209343D69B804FB728 /* Pods_IAR_CoreSDK_SampleTests.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		489C4ECA2797181000EC30EC /* SharedFiles */ = {
@@ -240,7 +232,7 @@
 				48C299DC278364BB00780AD3 /* IAR-CoreSDK-SampleUITests */,
 				48C299BA278364BA00780AD3 /* Products */,
 				13637614CA192FF5EB9216A0 /* Pods */,
-				264AEA2C93A96AFB09C8F942 /* Frameworks */,
+				7397313DDBC1ADAD83FB9A8D /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -258,6 +250,7 @@
 			isa = PBXGroup;
 			children = (
 				489C4ECA2797181000EC30EC /* SharedFiles */,
+				A3A3110827C6929000930630 /* DebugExtension */,
 				A3834C73279163D30097BA9E /* Views */,
 				A3834C69279163D30097BA9E /* Application */,
 				A3834C75279163D30097BA9E /* Controllers */,
@@ -283,6 +276,16 @@
 				48C299DF278364BB00780AD3 /* IAR_CoreSDK_SampleUITestsLaunchTests.swift */,
 			);
 			path = "IAR-CoreSDK-SampleUITests";
+			sourceTree = "<group>";
+		};
+		7397313DDBC1ADAD83FB9A8D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3DB43F84404BA2E68A6401FD /* Pods_IAR_CoreSDK_Sample.framework */,
+				F2FE9BF9B07C92F8A9B19B9A /* Pods_IAR_CoreSDK_Sample_IAR_CoreSDK_SampleUITests.framework */,
+				965A81FD884F8BDF07FBBC24 /* Pods_IAR_CoreSDK_SampleTests.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		A30D9C99279FA48100FE6410 /* PreviewCell */ = {
@@ -371,6 +374,14 @@
 			path = UserReward;
 			sourceTree = "<group>";
 		};
+		A3A3110827C6929000930630 /* DebugExtension */ = {
+			isa = PBXGroup;
+			children = (
+				A3A3110927C6929000930630 /* DebugLocationCommand.swift */,
+			);
+			path = DebugExtension;
+			sourceTree = "<group>";
+		};
 		A3C2B0D927A2584D00FE3A75 /* ARHunt */ = {
 			isa = PBXGroup;
 			children = (
@@ -389,12 +400,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 48C299E3278364BB00780AD3 /* Build configuration list for PBXNativeTarget "IAR-CoreSDK-Sample" */;
 			buildPhases = (
-				E4AC66BFC47E66433AA5513A /* [CP] Check Pods Manifest.lock */,
+				5E2356292A33D00BB37C2A87 /* [CP] Check Pods Manifest.lock */,
 				48C299B5278364BA00780AD3 /* Sources */,
 				48C299B6278364BA00780AD3 /* Frameworks */,
 				48C299B7278364BA00780AD3 /* Resources */,
 				486749682784D80F008EA52C /* Run Script (Swiftlint) */,
-				91A15AA4F09EBD3D7B8B41A8 /* [CP] Embed Pods Frameworks */,
+				5237B5525FF3A4854B749C6F /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -409,7 +420,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 48C299E6278364BB00780AD3 /* Build configuration list for PBXNativeTarget "IAR-CoreSDK-SampleTests" */;
 			buildPhases = (
-				4674C90F6318F8849FADA3A1 /* [CP] Check Pods Manifest.lock */,
+				F81489AD5CAFFF0FDDFB842F /* [CP] Check Pods Manifest.lock */,
 				48C299CB278364BB00780AD3 /* Sources */,
 				48C299CC278364BB00780AD3 /* Frameworks */,
 				48C299CD278364BB00780AD3 /* Resources */,
@@ -433,11 +444,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 48C299E9278364BB00780AD3 /* Build configuration list for PBXNativeTarget "IAR-CoreSDK-SampleUITests" */;
 			buildPhases = (
-				B09ECDA2FC89F424F1F86F39 /* [CP] Check Pods Manifest.lock */,
+				1391ABB1798B159CBC087658 /* [CP] Check Pods Manifest.lock */,
 				48C299D5278364BB00780AD3 /* Sources */,
 				48C299D6278364BB00780AD3 /* Frameworks */,
 				48C299D7278364BB00780AD3 /* Resources */,
-				98861C7C0ACDC6F7C5287394 /* [CP] Embed Pods Frameworks */,
+				AEE0C7F5B53AF1F9ECB8534D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -530,7 +541,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		4674C90F6318F8849FADA3A1 /* [CP] Check Pods Manifest.lock */ = {
+		1391ABB1798B159CBC087658 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -545,7 +556,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-IAR-CoreSDK-SampleTests-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -570,7 +581,7 @@
 			shellPath = /bin/sh;
 			shellScript = "# Tests if the script exists, to avoid breaking the build if distributed outside of controlled env\nScriptFile=$SRCROOT/../Scripts/swiftlint-locate-and-execute.sh\nif test -f \"$ScriptFile\"; then\n    echo \"$ScriptFile found - executing...\"\n    bash $ScriptFile $DERIVED_SOURCES_DIR\nfi\n";
 		};
-		91A15AA4F09EBD3D7B8B41A8 /* [CP] Embed Pods Frameworks */ = {
+		5237B5525FF3A4854B749C6F /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -587,46 +598,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IAR-CoreSDK-Sample/Pods-IAR-CoreSDK-Sample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		98861C7C0ACDC6F7C5287394 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B09ECDA2FC89F424F1F86F39 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E4AC66BFC47E66433AA5513A /* [CP] Check Pods Manifest.lock */ = {
+		5E2356292A33D00BB37C2A87 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -648,6 +620,45 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		AEE0C7F5B53AF1F9ECB8534D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests/Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F81489AD5CAFFF0FDDFB842F /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-IAR-CoreSDK-SampleTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -659,6 +670,7 @@
 				A30D9C9D279FA48100FE6410 /* PreviewCell.swift in Sources */,
 				A30D9C9F279FACCF00FE6410 /* UIImageView.swift in Sources */,
 				A3DBB60A27AD734500285E1E /* ARHuntRewardDetailsViewController.swift in Sources */,
+				A3A3110A27C6929000930630 /* DebugLocationCommand.swift in Sources */,
 				A370DA9527A58B3A00EC804A /* MarkerDetailsViewController.swift in Sources */,
 				A3DBB60C27AD9C5B00285E1E /* LocationMarkersViewController.swift in Sources */,
 				A396CBEC27A2F79800EF72CF /* UserRewardsViewController.swift in Sources */,
@@ -851,7 +863,7 @@
 		};
 		48C299E4278364BB00780AD3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 973259A892C575D88AFDCB54 /* Pods-IAR-CoreSDK-Sample.debug.xcconfig */;
+			baseConfigurationReference = 1C8A7611BA37B5F08C04DDC3 /* Pods-IAR-CoreSDK-Sample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -882,7 +894,7 @@
 		};
 		48C299E5278364BB00780AD3 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A683C13E29A5C6A581ACA482 /* Pods-IAR-CoreSDK-Sample.release.xcconfig */;
+			baseConfigurationReference = 9E5D1056BC628FE9B6235E1E /* Pods-IAR-CoreSDK-Sample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -913,7 +925,7 @@
 		};
 		48C299E7278364BB00780AD3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8EC3CF131ACB105DE435A41B /* Pods-IAR-CoreSDK-SampleTests.debug.xcconfig */;
+			baseConfigurationReference = 8D615D020FB89C206364F7B5 /* Pods-IAR-CoreSDK-SampleTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -939,7 +951,7 @@
 		};
 		48C299E8278364BB00780AD3 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8871C134A55B28B0A8EF7800 /* Pods-IAR-CoreSDK-SampleTests.release.xcconfig */;
+			baseConfigurationReference = 2A6C06465D467A023EF5A644 /* Pods-IAR-CoreSDK-SampleTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -965,7 +977,7 @@
 		};
 		48C299EA278364BB00780AD3 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 57CFA1C7D84C09483696BE5E /* Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.debug.xcconfig */;
+			baseConfigurationReference = C93D56B0F9AC4A2AB9A12B34 /* Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -989,7 +1001,7 @@
 		};
 		48C299EB278364BB00780AD3 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7883EBEC607823DA5E16F3B8 /* Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.release.xcconfig */;
+			baseConfigurationReference = 546C40EAA581B311326B0D84 /* Pods-IAR-CoreSDK-Sample-IAR-CoreSDK-SampleUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/IAR-CoreSDK-Sample/IAR-CoreSDK-Sample/Controllers/MenuController.swift
+++ b/IAR-CoreSDK-Sample/IAR-CoreSDK-Sample/Controllers/MenuController.swift
@@ -1,6 +1,6 @@
 //
 //  MenuController.swift
-//  IAR-TargetSDK-Sample
+//  IAR-CoreSDK-Sample
 //
 //  Created by Rogerio on 2021-12-23.
 //

--- a/IAR-CoreSDK-Sample/IAR-CoreSDK-Sample/DebugExtension/DebugLocationCommand.swift
+++ b/IAR-CoreSDK-Sample/IAR-CoreSDK-Sample/DebugExtension/DebugLocationCommand.swift
@@ -1,0 +1,52 @@
+//
+//  DebugLocationCommand.swift
+//  IAR_Example
+//
+//  Created by Rogerio on 2021-09-14.
+//  Copyright © 2021 CocoaPods. All rights reserved.
+//
+
+import Foundation
+import IAR_Core_SDK
+
+internal class DebugLocationCommand: IARDebugCommandProtocol {
+    
+    func terminate() {}
+
+    var key: String {
+        "location"
+    }
+    
+    var help: String {
+        "location [\(arguments.keys.joined(separator: "|"))]"
+    }
+    
+    var manual: String {
+        "Location utility. Parameters:\n• info - retuns last location retrieved\n• help - shows this help text"
+    }
+    
+    private typealias ArgumentFunction = () -> String
+    private lazy var arguments: [String: ArgumentFunction] = [
+        "info": locationInfo,
+        "help": executeHelp,
+    ]
+    
+    func execute(args: [String]) -> String {
+        guard let firstArg = args.first else {
+            return locationInfo()
+        }
+        
+        guard let firstPair = arguments[firstArg] else {
+            return "Invalid argument: \(firstArg) - Expected: \(help)"
+        }
+        
+        return firstPair()
+    }
+    
+    private func locationInfo() -> String {
+        guard let location = UserDefaults.standard.string(forKey: "SimulatedLocation") else {
+            return "No location history available"
+        }
+        return "Last location in memory: \(location)"
+    }
+}

--- a/IAR-CoreSDK-Sample/IAR-CoreSDK-Sample/ViewControllers/LocationMarkersViewController.swift
+++ b/IAR-CoreSDK-Sample/IAR-CoreSDK-Sample/ViewControllers/LocationMarkersViewController.swift
@@ -33,6 +33,7 @@ class LocationMarkersViewController: UIViewController {
         super.viewDidLoad()
         
         setupView()
+        setupLocation()
         getLocationMarkers()
     }
     
@@ -65,7 +66,24 @@ class LocationMarkersViewController: UIViewController {
         tableView.register(UINib(nibName: "LocationCell", bundle: nil), forCellReuseIdentifier: "LocationCellIdentifier")
     }
     
-    private func updateCoordinatesLabel() {
+    private func setupLocation(){
+        var simulatedLocation: String = "\(self.latitude);\(self.longitude)"
+        
+        // Check if there is a simulated location from the Degub tools
+        if DebugSettingsController.shared.simulatedLocation {
+            simulatedLocation = "\(DebugSettingsController.shared.simulatedLatitude);\(DebugSettingsController.shared.simulatedLongitude)"
+        }
+        
+        // If there is none, get the last simulated location for this device
+        else if let location = UserDefaults.standard.string(forKey: "SimulatedLocation") {
+                simulatedLocation = location
+        }
+        
+        updateCoordinates(simulatedLocation)
+    }
+    
+    private func updateLocation() {
+        UserDefaults.standard.set("\(self.latitude);\(self.longitude)", forKey: "SimulatedLocation")
         self.coordinatesLabel.text = "Coordinates: \(self.latitude);\(self.longitude). Radius: \(self.radius)"
     }
     
@@ -111,17 +129,23 @@ class LocationMarkersViewController: UIViewController {
     }
     
     private func updateCoordinates(_ coordinates: String) {
-        let newCoordinate = coordinates.split(separator: ";")
-        guard newCoordinate.count == 2 else {
+        guard coordinates.split(separator: ";").count == 2 else {
             self.present(UIAlertController.defaultDialog(title: "Invalid input", message: "Latitude and Longitude values need to be separated by ;"), animated: true, completion: nil)
             return
         }
         
+        getNewLocation(from: coordinates)
+        
+        self.updateLocation()
+        self.getLocationMarkers()
+    }
+    
+    private func getNewLocation(from stringLocation: String ) {
+        UserDefaults.standard.set(stringLocation, forKey: "SimulatedLocation")
+        let newCoordinate = stringLocation.split(separator: ";")
+        
         self.latitude = Double(newCoordinate[0]) ?? 0.0
         self.longitude = Double(newCoordinate[1]) ?? 0.0
-        
-        self.updateCoordinatesLabel()
-        self.getLocationMarkers()
     }
     
     private func onTakeMeThereButton(latitude: Double, longitude: Double) {

--- a/IAR-CoreSDK-Sample/IAR-CoreSDK-Sample/ViewControllers/MainViewController.swift
+++ b/IAR-CoreSDK-Sample/IAR-CoreSDK-Sample/ViewControllers/MainViewController.swift
@@ -110,7 +110,10 @@ extension MainViewController: UITableViewDelegate {
             case .arHunts:
                 self.performSegue(withIdentifier: "segueARHunts", sender: nil)
             case .debugTools:
-                let view = IARDebugViewController(customCommands: [])
+                // You can add custom commands if you want to on the debugTool
+                // In this example, we are adding a custom location
+                // For more details, see "DebugLocationCommand"
+                let view = IARDebugViewController(customCommands: [DebugLocationCommand()])
                 self.navigationController?.pushViewController(view, animated: true)
         }
     }

--- a/IAR-SurfaceSDK-Sample/IAR-SurfaceSDK-Sample.xcodeproj/project.pbxproj
+++ b/IAR-SurfaceSDK-Sample/IAR-SurfaceSDK-Sample.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		2BBBD5D5143D4CF21BD3CF4E /* Pods_IAR_SurfaceSDK_SampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5521453C86E89F9D5673772 /* Pods_IAR_SurfaceSDK_SampleTests.framework */; };
 		4853EA65278647120067B6A8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4853EA64278647120067B6A8 /* AppDelegate.swift */; };
 		4853EA67278647120067B6A8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4853EA66278647120067B6A8 /* SceneDelegate.swift */; };
 		4853EA69278647120067B6A8 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4853EA68278647120067B6A8 /* MainViewController.swift */; };
@@ -32,7 +31,6 @@
 		488F2E7727A3027800D90883 /* NFCWriteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488F2E7627A3027800D90883 /* NFCWriteViewController.swift */; };
 		488F2E7C27A338F400D90883 /* NFCReadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 488F2E7B27A338F400D90883 /* NFCReadViewController.swift */; };
 		48AE2C4A27B1C6CC00E8B339 /* SurfaceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AE2C4927B1C6CC00E8B339 /* SurfaceViewController.swift */; };
-		4FCBFE20690474217DC02034 /* Pods_IAR_SurfaceSDK_Sample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7607D193428B59C9F1647426 /* Pods_IAR_SurfaceSDK_Sample.framework */; };
 		A307BF3B2791C0EF00C9DB5B /* MenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A307BF392791C0EF00C9DB5B /* MenuController.swift */; };
 		A307BF3F2791C12800C9DB5B /* MenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = A307BF3E2791C12800C9DB5B /* MenuItem.swift */; };
 		A307BF422791C3AA00C9DB5B /* mainViewHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = A307BF412791C3AA00C9DB5B /* mainViewHeader.xib */; };
@@ -41,7 +39,9 @@
 		A32A43D827BAB10000630EA7 /* LocationCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = A32A43D427BAB10000630EA7 /* LocationCell.xib */; };
 		A32A43D927BAB10000630EA7 /* LocationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32A43D527BAB10000630EA7 /* LocationCell.swift */; };
 		A32A43DB27BAB1AF00630EA7 /* UIImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A32A43DA27BAB1AF00630EA7 /* UIImageView.swift */; };
-		A907C8603CEA4CC4EC3C72B5 /* Pods_IAR_SurfaceSDK_Sample_IAR_SurfaceSDK_SampleUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9FB9029A0F8F57F395C9F721 /* Pods_IAR_SurfaceSDK_Sample_IAR_SurfaceSDK_SampleUITests.framework */; };
+		BA25F36A638FC75D592B3F39 /* Pods_IAR_SurfaceSDK_Sample_IAR_SurfaceSDK_SampleUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1BD29EEA6DA9DC4FA8ED5BB5 /* Pods_IAR_SurfaceSDK_Sample_IAR_SurfaceSDK_SampleUITests.framework */; };
+		E844E3E4300C96FA0C083222 /* Pods_IAR_SurfaceSDK_SampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09804045365EEDF4F3CF27C6 /* Pods_IAR_SurfaceSDK_SampleTests.framework */; };
+		EDD164D0C9780BE34CD3E254 /* Pods_IAR_SurfaceSDK_Sample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D73F1D990A48EC7291A84664 /* Pods_IAR_SurfaceSDK_Sample.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -62,7 +62,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		40E304E63F8E043B558F5839 /* Pods-IAR-SurfaceSDK-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-SurfaceSDK-Sample.debug.xcconfig"; path = "Target Support Files/Pods-IAR-SurfaceSDK-Sample/Pods-IAR-SurfaceSDK-Sample.debug.xcconfig"; sourceTree = "<group>"; };
+		09804045365EEDF4F3CF27C6 /* Pods_IAR_SurfaceSDK_SampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_SurfaceSDK_SampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1BD29EEA6DA9DC4FA8ED5BB5 /* Pods_IAR_SurfaceSDK_Sample_IAR_SurfaceSDK_SampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_SurfaceSDK_Sample_IAR_SurfaceSDK_SampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4853EA61278647120067B6A8 /* IAR-SurfaceSDK-Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "IAR-SurfaceSDK-Sample.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4853EA64278647120067B6A8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		4853EA66278647120067B6A8 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -89,12 +90,9 @@
 		488F2E7627A3027800D90883 /* NFCWriteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCWriteViewController.swift; sourceTree = "<group>"; };
 		488F2E7B27A338F400D90883 /* NFCReadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCReadViewController.swift; sourceTree = "<group>"; };
 		48AE2C4927B1C6CC00E8B339 /* SurfaceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceViewController.swift; sourceTree = "<group>"; };
-		7607D193428B59C9F1647426 /* Pods_IAR_SurfaceSDK_Sample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_SurfaceSDK_Sample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		787103E4F66F22FA7766CEC3 /* Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.release.xcconfig"; path = "Target Support Files/Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests/Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.release.xcconfig"; sourceTree = "<group>"; };
-		7A724349340C76141379412F /* Pods-IAR-SurfaceSDK-SampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-SurfaceSDK-SampleTests.release.xcconfig"; path = "Target Support Files/Pods-IAR-SurfaceSDK-SampleTests/Pods-IAR-SurfaceSDK-SampleTests.release.xcconfig"; sourceTree = "<group>"; };
-		86BF250B70DEDAA7C87D9BB9 /* Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.debug.xcconfig"; path = "Target Support Files/Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests/Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
-		9929759BA029A23E42347D85 /* Pods-IAR-SurfaceSDK-Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-SurfaceSDK-Sample.release.xcconfig"; path = "Target Support Files/Pods-IAR-SurfaceSDK-Sample/Pods-IAR-SurfaceSDK-Sample.release.xcconfig"; sourceTree = "<group>"; };
-		9FB9029A0F8F57F395C9F721 /* Pods_IAR_SurfaceSDK_Sample_IAR_SurfaceSDK_SampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_SurfaceSDK_Sample_IAR_SurfaceSDK_SampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4B102FCA4E2519AEC510B418 /* Pods-IAR-SurfaceSDK-SampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-SurfaceSDK-SampleTests.release.xcconfig"; path = "Target Support Files/Pods-IAR-SurfaceSDK-SampleTests/Pods-IAR-SurfaceSDK-SampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		64392CB243BF20A8FCFE5C4C /* Pods-IAR-SurfaceSDK-Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-SurfaceSDK-Sample.release.xcconfig"; path = "Target Support Files/Pods-IAR-SurfaceSDK-Sample/Pods-IAR-SurfaceSDK-Sample.release.xcconfig"; sourceTree = "<group>"; };
+		7DDE4614125D96EC3B2734E4 /* Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.release.xcconfig"; path = "Target Support Files/Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests/Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.release.xcconfig"; sourceTree = "<group>"; };
 		A307BF392791C0EF00C9DB5B /* MenuController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuController.swift; sourceTree = "<group>"; };
 		A307BF3E2791C12800C9DB5B /* MenuItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MenuItem.swift; sourceTree = "<group>"; };
 		A307BF412791C3AA00C9DB5B /* mainViewHeader.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = mainViewHeader.xib; sourceTree = "<group>"; };
@@ -103,8 +101,10 @@
 		A32A43D427BAB10000630EA7 /* LocationCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LocationCell.xib; sourceTree = "<group>"; };
 		A32A43D527BAB10000630EA7 /* LocationCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationCell.swift; sourceTree = "<group>"; };
 		A32A43DA27BAB1AF00630EA7 /* UIImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIImageView.swift; path = "../../../../../IAR-Samples-Common/Extensions/UIKit/UIImageView.swift"; sourceTree = "<group>"; };
-		CF09C84B4151628B9E385454 /* Pods-IAR-SurfaceSDK-SampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-SurfaceSDK-SampleTests.debug.xcconfig"; path = "Target Support Files/Pods-IAR-SurfaceSDK-SampleTests/Pods-IAR-SurfaceSDK-SampleTests.debug.xcconfig"; sourceTree = "<group>"; };
-		D5521453C86E89F9D5673772 /* Pods_IAR_SurfaceSDK_SampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_SurfaceSDK_SampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB78BD51AABF1417C0F79A15 /* Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.debug.xcconfig"; path = "Target Support Files/Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests/Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		D73F1D990A48EC7291A84664 /* Pods_IAR_SurfaceSDK_Sample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_SurfaceSDK_Sample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D85E3ED6D17C96E0706766B3 /* Pods-IAR-SurfaceSDK-SampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-SurfaceSDK-SampleTests.debug.xcconfig"; path = "Target Support Files/Pods-IAR-SurfaceSDK-SampleTests/Pods-IAR-SurfaceSDK-SampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		FFE2A6D97D88D290A523C809 /* Pods-IAR-SurfaceSDK-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-SurfaceSDK-Sample.debug.xcconfig"; path = "Target Support Files/Pods-IAR-SurfaceSDK-Sample/Pods-IAR-SurfaceSDK-Sample.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,7 +112,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4FCBFE20690474217DC02034 /* Pods_IAR_SurfaceSDK_Sample.framework in Frameworks */,
+				EDD164D0C9780BE34CD3E254 /* Pods_IAR_SurfaceSDK_Sample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -123,7 +123,7 @@
 				48658418279F187300BC41DD /* SpecLeaks in Frameworks */,
 				48658415279F185C00BC41DD /* Quick in Frameworks */,
 				48658412279F184100BC41DD /* Nimble in Frameworks */,
-				2BBBD5D5143D4CF21BD3CF4E /* Pods_IAR_SurfaceSDK_SampleTests.framework in Frameworks */,
+				E844E3E4300C96FA0C083222 /* Pods_IAR_SurfaceSDK_SampleTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -131,7 +131,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A907C8603CEA4CC4EC3C72B5 /* Pods_IAR_SurfaceSDK_Sample_IAR_SurfaceSDK_SampleUITests.framework in Frameworks */,
+				BA25F36A638FC75D592B3F39 /* Pods_IAR_SurfaceSDK_Sample_IAR_SurfaceSDK_SampleUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -146,7 +146,7 @@
 				4853EA84278647130067B6A8 /* IAR-SurfaceSDK-SampleUITests */,
 				4853EA62278647120067B6A8 /* Products */,
 				FEAB6F7A9FF9B4B7064A4896 /* Pods */,
-				50FF49F3B2DB063B0978AE79 /* Frameworks */,
+				BDE7C0DBE3D910B60B4E06F3 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -255,16 +255,6 @@
 			path = UIKit;
 			sourceTree = "<group>";
 		};
-		50FF49F3B2DB063B0978AE79 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				7607D193428B59C9F1647426 /* Pods_IAR_SurfaceSDK_Sample.framework */,
-				9FB9029A0F8F57F395C9F721 /* Pods_IAR_SurfaceSDK_Sample_IAR_SurfaceSDK_SampleUITests.framework */,
-				D5521453C86E89F9D5673772 /* Pods_IAR_SurfaceSDK_SampleTests.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		A307BF382791C0EF00C9DB5B /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
@@ -358,15 +348,25 @@
 			path = Surface;
 			sourceTree = "<group>";
 		};
+		BDE7C0DBE3D910B60B4E06F3 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D73F1D990A48EC7291A84664 /* Pods_IAR_SurfaceSDK_Sample.framework */,
+				1BD29EEA6DA9DC4FA8ED5BB5 /* Pods_IAR_SurfaceSDK_Sample_IAR_SurfaceSDK_SampleUITests.framework */,
+				09804045365EEDF4F3CF27C6 /* Pods_IAR_SurfaceSDK_SampleTests.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		FEAB6F7A9FF9B4B7064A4896 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				40E304E63F8E043B558F5839 /* Pods-IAR-SurfaceSDK-Sample.debug.xcconfig */,
-				9929759BA029A23E42347D85 /* Pods-IAR-SurfaceSDK-Sample.release.xcconfig */,
-				86BF250B70DEDAA7C87D9BB9 /* Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.debug.xcconfig */,
-				787103E4F66F22FA7766CEC3 /* Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.release.xcconfig */,
-				CF09C84B4151628B9E385454 /* Pods-IAR-SurfaceSDK-SampleTests.debug.xcconfig */,
-				7A724349340C76141379412F /* Pods-IAR-SurfaceSDK-SampleTests.release.xcconfig */,
+				FFE2A6D97D88D290A523C809 /* Pods-IAR-SurfaceSDK-Sample.debug.xcconfig */,
+				64392CB243BF20A8FCFE5C4C /* Pods-IAR-SurfaceSDK-Sample.release.xcconfig */,
+				AB78BD51AABF1417C0F79A15 /* Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.debug.xcconfig */,
+				7DDE4614125D96EC3B2734E4 /* Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.release.xcconfig */,
+				D85E3ED6D17C96E0706766B3 /* Pods-IAR-SurfaceSDK-SampleTests.debug.xcconfig */,
+				4B102FCA4E2519AEC510B418 /* Pods-IAR-SurfaceSDK-SampleTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -378,11 +378,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4853EA8B278647130067B6A8 /* Build configuration list for PBXNativeTarget "IAR-SurfaceSDK-Sample" */;
 			buildPhases = (
-				FB73582ED1E8F187011F0E4B /* [CP] Check Pods Manifest.lock */,
+				42FB2CF51B9E5AF3D8C158B2 /* [CP] Check Pods Manifest.lock */,
 				4853EA5D278647120067B6A8 /* Sources */,
 				4853EA5E278647120067B6A8 /* Frameworks */,
 				4853EA5F278647120067B6A8 /* Resources */,
-				D1D479AF5E1A708001286C87 /* [CP] Embed Pods Frameworks */,
+				9964C60F55F08009DDB282F7 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -397,7 +397,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4853EA8E278647130067B6A8 /* Build configuration list for PBXNativeTarget "IAR-SurfaceSDK-SampleTests" */;
 			buildPhases = (
-				B95960A0CE0A7106ACB42FF2 /* [CP] Check Pods Manifest.lock */,
+				FEB519893B07EB6AB7189574 /* [CP] Check Pods Manifest.lock */,
 				4853EA73278647130067B6A8 /* Sources */,
 				4853EA74278647130067B6A8 /* Frameworks */,
 				4853EA75278647130067B6A8 /* Resources */,
@@ -421,11 +421,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4853EA91278647130067B6A8 /* Build configuration list for PBXNativeTarget "IAR-SurfaceSDK-SampleUITests" */;
 			buildPhases = (
-				CF850100EA111F762CE2CFBB /* [CP] Check Pods Manifest.lock */,
+				63A62F2EFF7408D79479B76D /* [CP] Check Pods Manifest.lock */,
 				4853EA7D278647130067B6A8 /* Sources */,
 				4853EA7E278647130067B6A8 /* Frameworks */,
 				4853EA7F278647130067B6A8 /* Resources */,
-				654D7A1317FCBD22E3C8F243 /* [CP] Embed Pods Frameworks */,
+				3B50AFB7EB51C655EED91814 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -517,7 +517,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		654D7A1317FCBD22E3C8F243 /* [CP] Embed Pods Frameworks */ = {
+		3B50AFB7EB51C655EED91814 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -534,7 +534,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests/Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B95960A0CE0A7106ACB42FF2 /* [CP] Check Pods Manifest.lock */ = {
+		42FB2CF51B9E5AF3D8C158B2 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -549,14 +549,14 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-IAR-SurfaceSDK-SampleTests-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-IAR-SurfaceSDK-Sample-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		CF850100EA111F762CE2CFBB /* [CP] Check Pods Manifest.lock */ = {
+		63A62F2EFF7408D79479B76D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -578,7 +578,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D1D479AF5E1A708001286C87 /* [CP] Embed Pods Frameworks */ = {
+		9964C60F55F08009DDB282F7 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -595,7 +595,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IAR-SurfaceSDK-Sample/Pods-IAR-SurfaceSDK-Sample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		FB73582ED1E8F187011F0E4B /* [CP] Check Pods Manifest.lock */ = {
+		FEB519893B07EB6AB7189574 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -610,7 +610,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-IAR-SurfaceSDK-Sample-checkManifestLockResult.txt",
+				"$(DERIVED_FILE_DIR)/Pods-IAR-SurfaceSDK-SampleTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -816,7 +816,7 @@
 		};
 		4853EA8C278647130067B6A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 40E304E63F8E043B558F5839 /* Pods-IAR-SurfaceSDK-Sample.debug.xcconfig */;
+			baseConfigurationReference = FFE2A6D97D88D290A523C809 /* Pods-IAR-SurfaceSDK-Sample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -851,7 +851,7 @@
 		};
 		4853EA8D278647130067B6A8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9929759BA029A23E42347D85 /* Pods-IAR-SurfaceSDK-Sample.release.xcconfig */;
+			baseConfigurationReference = 64392CB243BF20A8FCFE5C4C /* Pods-IAR-SurfaceSDK-Sample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -886,7 +886,7 @@
 		};
 		4853EA8F278647130067B6A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CF09C84B4151628B9E385454 /* Pods-IAR-SurfaceSDK-SampleTests.debug.xcconfig */;
+			baseConfigurationReference = D85E3ED6D17C96E0706766B3 /* Pods-IAR-SurfaceSDK-SampleTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -912,7 +912,7 @@
 		};
 		4853EA90278647130067B6A8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7A724349340C76141379412F /* Pods-IAR-SurfaceSDK-SampleTests.release.xcconfig */;
+			baseConfigurationReference = 4B102FCA4E2519AEC510B418 /* Pods-IAR-SurfaceSDK-SampleTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -938,7 +938,7 @@
 		};
 		4853EA92278647130067B6A8 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 86BF250B70DEDAA7C87D9BB9 /* Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.debug.xcconfig */;
+			baseConfigurationReference = AB78BD51AABF1417C0F79A15 /* Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -962,7 +962,7 @@
 		};
 		4853EA93278647130067B6A8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 787103E4F66F22FA7766CEC3 /* Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.release.xcconfig */;
+			baseConfigurationReference = 7DDE4614125D96EC3B2734E4 /* Pods-IAR-SurfaceSDK-Sample-IAR-SurfaceSDK-SampleUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;

--- a/IAR-TargetSDK-Sample/IAR-TargetSDK-Sample.xcodeproj/project.pbxproj
+++ b/IAR-TargetSDK-Sample/IAR-TargetSDK-Sample.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		21CFD709F9E7672AC468114D /* Pods_IAR_TargetSDK_SampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA356F787C5BBAEAF6189E6A /* Pods_IAR_TargetSDK_SampleTests.framework */; };
-		23A65B2B4125010687A475E6 /* Pods_IAR_TargetSDK_Sample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B294400B42F1EA838E99F76C /* Pods_IAR_TargetSDK_Sample.framework */; };
 		4853EA9627877BD50067B6A8 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 4853EA9527877BD50067B6A8 /* Nimble */; };
 		4853EA9927877BED0067B6A8 /* Quick in Frameworks */ = {isa = PBXBuildFile; productRef = 4853EA9827877BED0067B6A8 /* Quick */; };
 		4853EA9C27877C090067B6A8 /* SpecLeaks in Frameworks */ = {isa = PBXBuildFile; productRef = 4853EA9B27877C090067B6A8 /* SpecLeaks */; };
@@ -29,10 +27,12 @@
 		489C4EC127908DEB00EC30EC /* ExternalUsersController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C4EC027908DEB00EC30EC /* ExternalUsersController.swift */; };
 		489C4EC627908F9000EC30EC /* UserManagementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C4EC527908F9000EC30EC /* UserManagementViewModel.swift */; };
 		489C4EC92790912A00EC30EC /* UIAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489C4EC82790912A00EC30EC /* UIAlertController.swift */; };
-		70DFD828C00B9BDF40BEE233 /* Pods_IAR_TargetSDK_SampleUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D107D940F02B1BA028F4A6B /* Pods_IAR_TargetSDK_SampleUITests.framework */; };
+		591DDEA0C2BB5D13409339EB /* Pods_IAR_TargetSDK_Sample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DBD6BC1CDA9FCA8672C4DC9 /* Pods_IAR_TargetSDK_Sample.framework */; };
+		709D5097019026D4DCA7A8B6 /* Pods_IAR_TargetSDK_SampleTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FA471EBB912F565FA550D4A4 /* Pods_IAR_TargetSDK_SampleTests.framework */; };
 		A30D9C97279F80F600FE6410 /* UserManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A30D9C95279F80F600FE6410 /* UserManagementViewController.swift */; };
 		A30D9C98279F80F600FE6410 /* UserManagementViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A30D9C96279F80F600FE6410 /* UserManagementViewController.xib */; };
 		A3E1D692278CEEE00086147A /* ScanARViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3E1D691278CEEE00086147A /* ScanARViewController.swift */; };
+		CBFD45B8B685CBA130C94785 /* Pods_IAR_TargetSDK_SampleUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 500FA324CCC3CCAC2F76289C /* Pods_IAR_TargetSDK_SampleUITests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,7 +53,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		202740A36F48016126B8C0C5 /* Pods-IAR-TargetSDK-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-TargetSDK-Sample.debug.xcconfig"; path = "Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample.debug.xcconfig"; sourceTree = "<group>"; };
+		33577DD3883E839C8601029C /* Pods-IAR-TargetSDK-Sample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-TargetSDK-Sample.debug.xcconfig"; path = "Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample.debug.xcconfig"; sourceTree = "<group>"; };
+		3DBD6BC1CDA9FCA8672C4DC9 /* Pods_IAR_TargetSDK_Sample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_TargetSDK_Sample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		48776C562774FD9B00BD0F33 /* MenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuController.swift; sourceTree = "<group>"; };
 		4891EBB127751590001C616C /* mainViewHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = mainViewHeader.xib; sourceTree = "<group>"; };
 		48938F1627651B9B00D0438A /* IAR-TargetSDK-Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "IAR-TargetSDK-Sample.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -75,17 +76,16 @@
 		489C4EC027908DEB00EC30EC /* ExternalUsersController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ExternalUsersController.swift; path = "../../../../IAR-Samples-Common/Controllers/ExternalUsersController.swift"; sourceTree = "<group>"; };
 		489C4EC527908F9000EC30EC /* UserManagementViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserManagementViewModel.swift; path = "../../../../IAR-Samples-Common/ViewModels/UserManagementViewModel.swift"; sourceTree = "<group>"; };
 		489C4EC82790912A00EC30EC /* UIAlertController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIAlertController.swift; path = "../../../../IAR-Samples-Common/Extensions/UIKit/UIAlertController.swift"; sourceTree = "<group>"; };
-		6D107D940F02B1BA028F4A6B /* Pods_IAR_TargetSDK_SampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_TargetSDK_SampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		8E93DA229ABF4847C2593E68 /* Pods-IAR-TargetSDK-SampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-TargetSDK-SampleUITests.release.xcconfig"; path = "Target Support Files/Pods-IAR-TargetSDK-SampleUITests/Pods-IAR-TargetSDK-SampleUITests.release.xcconfig"; sourceTree = "<group>"; };
+		500FA324CCC3CCAC2F76289C /* Pods_IAR_TargetSDK_SampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_TargetSDK_SampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6063A0610E9241BDE18F1CEB /* Pods-IAR-TargetSDK-SampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-TargetSDK-SampleUITests.debug.xcconfig"; path = "Target Support Files/Pods-IAR-TargetSDK-SampleUITests/Pods-IAR-TargetSDK-SampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		7B659FE4BD4E7F552547EF4F /* Pods-IAR-TargetSDK-SampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-TargetSDK-SampleTests.release.xcconfig"; path = "Target Support Files/Pods-IAR-TargetSDK-SampleTests/Pods-IAR-TargetSDK-SampleTests.release.xcconfig"; sourceTree = "<group>"; };
+		7EDAA03C76363F4A51C5C4F8 /* Pods-IAR-TargetSDK-SampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-TargetSDK-SampleTests.debug.xcconfig"; path = "Target Support Files/Pods-IAR-TargetSDK-SampleTests/Pods-IAR-TargetSDK-SampleTests.debug.xcconfig"; sourceTree = "<group>"; };
+		9CDC1B37E332E830552FD51D /* Pods-IAR-TargetSDK-SampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-TargetSDK-SampleUITests.release.xcconfig"; path = "Target Support Files/Pods-IAR-TargetSDK-SampleUITests/Pods-IAR-TargetSDK-SampleUITests.release.xcconfig"; sourceTree = "<group>"; };
 		A30D9C95279F80F600FE6410 /* UserManagementViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserManagementViewController.swift; path = "../../../../IAR-Samples-Common/ViewControllers/UserManagementViewController.swift"; sourceTree = "<group>"; };
 		A30D9C96279F80F600FE6410 /* UserManagementViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; name = UserManagementViewController.xib; path = "../../../../IAR-Samples-Common/ViewControllers/UserManagementViewController.xib"; sourceTree = "<group>"; };
 		A3E1D691278CEEE00086147A /* ScanARViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScanARViewController.swift; sourceTree = "<group>"; };
-		A71CF17B285393A8B5FFF4E1 /* Pods-IAR-TargetSDK-SampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-TargetSDK-SampleTests.debug.xcconfig"; path = "Target Support Files/Pods-IAR-TargetSDK-SampleTests/Pods-IAR-TargetSDK-SampleTests.debug.xcconfig"; sourceTree = "<group>"; };
-		B20BCE2EFC27A10E6AF79DF7 /* Pods-IAR-TargetSDK-Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-TargetSDK-Sample.release.xcconfig"; path = "Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample.release.xcconfig"; sourceTree = "<group>"; };
-		B294400B42F1EA838E99F76C /* Pods_IAR_TargetSDK_Sample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_TargetSDK_Sample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CBB95C0F02807E2717F17EA5 /* Pods-IAR-TargetSDK-SampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-TargetSDK-SampleUITests.debug.xcconfig"; path = "Target Support Files/Pods-IAR-TargetSDK-SampleUITests/Pods-IAR-TargetSDK-SampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
-		D4E598F470EEE84C3EE5D7A0 /* Pods-IAR-TargetSDK-SampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-TargetSDK-SampleTests.release.xcconfig"; path = "Target Support Files/Pods-IAR-TargetSDK-SampleTests/Pods-IAR-TargetSDK-SampleTests.release.xcconfig"; sourceTree = "<group>"; };
-		DA356F787C5BBAEAF6189E6A /* Pods_IAR_TargetSDK_SampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_TargetSDK_SampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C150B74172BD438013C1FA60 /* Pods-IAR-TargetSDK-Sample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IAR-TargetSDK-Sample.release.xcconfig"; path = "Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample.release.xcconfig"; sourceTree = "<group>"; };
+		FA471EBB912F565FA550D4A4 /* Pods_IAR_TargetSDK_SampleTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_IAR_TargetSDK_SampleTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,7 +93,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				23A65B2B4125010687A475E6 /* Pods_IAR_TargetSDK_Sample.framework in Frameworks */,
+				591DDEA0C2BB5D13409339EB /* Pods_IAR_TargetSDK_Sample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -104,7 +104,7 @@
 				4853EA9C27877C090067B6A8 /* SpecLeaks in Frameworks */,
 				4853EA9927877BED0067B6A8 /* Quick in Frameworks */,
 				4853EA9627877BD50067B6A8 /* Nimble in Frameworks */,
-				21CFD709F9E7672AC468114D /* Pods_IAR_TargetSDK_SampleTests.framework in Frameworks */,
+				709D5097019026D4DCA7A8B6 /* Pods_IAR_TargetSDK_SampleTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -112,19 +112,19 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				70DFD828C00B9BDF40BEE233 /* Pods_IAR_TargetSDK_SampleUITests.framework in Frameworks */,
+				CBFD45B8B685CBA130C94785 /* Pods_IAR_TargetSDK_SampleUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		480B648B9642E24CD33F1A81 /* Frameworks */ = {
+		363A176666D4F4E1B6187D9D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				B294400B42F1EA838E99F76C /* Pods_IAR_TargetSDK_Sample.framework */,
-				DA356F787C5BBAEAF6189E6A /* Pods_IAR_TargetSDK_SampleTests.framework */,
-				6D107D940F02B1BA028F4A6B /* Pods_IAR_TargetSDK_SampleUITests.framework */,
+				3DBD6BC1CDA9FCA8672C4DC9 /* Pods_IAR_TargetSDK_Sample.framework */,
+				FA471EBB912F565FA550D4A4 /* Pods_IAR_TargetSDK_SampleTests.framework */,
+				500FA324CCC3CCAC2F76289C /* Pods_IAR_TargetSDK_SampleUITests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -173,7 +173,7 @@
 				48938F3927651B9C00D0438A /* IAR-TargetSDK-SampleUITests */,
 				48938F1727651B9B00D0438A /* Products */,
 				C29A852A0EEE1E87F3771FD6 /* Pods */,
-				480B648B9642E24CD33F1A81 /* Frameworks */,
+				363A176666D4F4E1B6187D9D /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -292,12 +292,12 @@
 		C29A852A0EEE1E87F3771FD6 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				202740A36F48016126B8C0C5 /* Pods-IAR-TargetSDK-Sample.debug.xcconfig */,
-				B20BCE2EFC27A10E6AF79DF7 /* Pods-IAR-TargetSDK-Sample.release.xcconfig */,
-				A71CF17B285393A8B5FFF4E1 /* Pods-IAR-TargetSDK-SampleTests.debug.xcconfig */,
-				D4E598F470EEE84C3EE5D7A0 /* Pods-IAR-TargetSDK-SampleTests.release.xcconfig */,
-				CBB95C0F02807E2717F17EA5 /* Pods-IAR-TargetSDK-SampleUITests.debug.xcconfig */,
-				8E93DA229ABF4847C2593E68 /* Pods-IAR-TargetSDK-SampleUITests.release.xcconfig */,
+				33577DD3883E839C8601029C /* Pods-IAR-TargetSDK-Sample.debug.xcconfig */,
+				C150B74172BD438013C1FA60 /* Pods-IAR-TargetSDK-Sample.release.xcconfig */,
+				7EDAA03C76363F4A51C5C4F8 /* Pods-IAR-TargetSDK-SampleTests.debug.xcconfig */,
+				7B659FE4BD4E7F552547EF4F /* Pods-IAR-TargetSDK-SampleTests.release.xcconfig */,
+				6063A0610E9241BDE18F1CEB /* Pods-IAR-TargetSDK-SampleUITests.debug.xcconfig */,
+				9CDC1B37E332E830552FD51D /* Pods-IAR-TargetSDK-SampleUITests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -309,13 +309,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 48938F4027651B9C00D0438A /* Build configuration list for PBXNativeTarget "IAR-TargetSDK-Sample" */;
 			buildPhases = (
-				C65BEA202843155D3860D252 /* [CP] Check Pods Manifest.lock */,
+				593AE37B312E06FF68E2A869 /* [CP] Check Pods Manifest.lock */,
 				48938F1227651B9B00D0438A /* Sources */,
 				48938F1327651B9B00D0438A /* Frameworks */,
 				48938F1427651B9B00D0438A /* Resources */,
 				48776C532774DF5900BD0F33 /* Run Script (Swiftlint) */,
-				2BA8D52338E543881482F858 /* [CP] Embed Pods Frameworks */,
-				A2DC182900C9C890527C7F74 /* [CP] Copy Pods Resources */,
+				CE2FBE557B653C06FD78BD72 /* [CP] Embed Pods Frameworks */,
+				C1E776FE732B3B04702101B1 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -330,7 +330,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 48938F4327651B9C00D0438A /* Build configuration list for PBXNativeTarget "IAR-TargetSDK-SampleTests" */;
 			buildPhases = (
-				D2DA178718EB1571ED613903 /* [CP] Check Pods Manifest.lock */,
+				B45518DA96A898E5A1683CF4 /* [CP] Check Pods Manifest.lock */,
 				48938F2827651B9C00D0438A /* Sources */,
 				48938F2927651B9C00D0438A /* Frameworks */,
 				48938F2A27651B9C00D0438A /* Resources */,
@@ -354,12 +354,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 48938F4627651B9C00D0438A /* Build configuration list for PBXNativeTarget "IAR-TargetSDK-SampleUITests" */;
 			buildPhases = (
-				2FF41231D12E7F855E369020 /* [CP] Check Pods Manifest.lock */,
+				14F6655D175603527663EEBD /* [CP] Check Pods Manifest.lock */,
 				48938F3227651B9C00D0438A /* Sources */,
 				48938F3327651B9C00D0438A /* Frameworks */,
 				48938F3427651B9C00D0438A /* Resources */,
-				889E7A5A93216D1122993771 /* [CP] Embed Pods Frameworks */,
-				F176A9D1ACA9F386673A6F27 /* [CP] Copy Pods Resources */,
+				13DBF524BD5F5F5677190260 /* [CP] Embed Pods Frameworks */,
+				E7336477EB452EF006ECEDC3 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -449,24 +449,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2BA8D52338E543881482F858 /* [CP] Embed Pods Frameworks */ = {
+		13DBF524BD5F5F5677190260 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-SampleUITests/Pods-IAR-TargetSDK-SampleUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-SampleUITests/Pods-IAR-TargetSDK-SampleUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-SampleUITests/Pods-IAR-TargetSDK-SampleUITests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2FF41231D12E7F855E369020 /* [CP] Check Pods Manifest.lock */ = {
+		14F6655D175603527663EEBD /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -506,41 +506,7 @@
 			shellPath = /bin/sh;
 			shellScript = "# Tests if the script exists, to avoid breaking the build if distributed outside of controlled env\nScriptFile=$SRCROOT/../Scripts/swiftlint-locate-and-execute.sh\nif test -f \"$ScriptFile\"; then\n    echo \"$ScriptFile found - executing...\"\n    bash $ScriptFile $DERIVED_SOURCES_DIR\nfi\n";
 		};
-		889E7A5A93216D1122993771 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-SampleUITests/Pods-IAR-TargetSDK-SampleUITests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-SampleUITests/Pods-IAR-TargetSDK-SampleUITests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-SampleUITests/Pods-IAR-TargetSDK-SampleUITests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		A2DC182900C9C890527C7F74 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C65BEA202843155D3860D252 /* [CP] Check Pods Manifest.lock */ = {
+		593AE37B312E06FF68E2A869 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -562,7 +528,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D2DA178718EB1571ED613903 /* [CP] Check Pods Manifest.lock */ = {
+		B45518DA96A898E5A1683CF4 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -584,7 +550,41 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F176A9D1ACA9F386673A6F27 /* [CP] Copy Pods Resources */ = {
+		C1E776FE732B3B04702101B1 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CE2FBE557B653C06FD78BD72 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IAR-TargetSDK-Sample/Pods-IAR-TargetSDK-Sample-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E7336477EB452EF006ECEDC3 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -793,7 +793,7 @@
 		};
 		48938F4127651B9C00D0438A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 202740A36F48016126B8C0C5 /* Pods-IAR-TargetSDK-Sample.debug.xcconfig */;
+			baseConfigurationReference = 33577DD3883E839C8601029C /* Pods-IAR-TargetSDK-Sample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -827,7 +827,7 @@
 		};
 		48938F4227651B9C00D0438A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B20BCE2EFC27A10E6AF79DF7 /* Pods-IAR-TargetSDK-Sample.release.xcconfig */;
+			baseConfigurationReference = C150B74172BD438013C1FA60 /* Pods-IAR-TargetSDK-Sample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -861,7 +861,7 @@
 		};
 		48938F4427651B9C00D0438A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A71CF17B285393A8B5FFF4E1 /* Pods-IAR-TargetSDK-SampleTests.debug.xcconfig */;
+			baseConfigurationReference = 7EDAA03C76363F4A51C5C4F8 /* Pods-IAR-TargetSDK-SampleTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -887,7 +887,7 @@
 		};
 		48938F4527651B9C00D0438A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D4E598F470EEE84C3EE5D7A0 /* Pods-IAR-TargetSDK-SampleTests.release.xcconfig */;
+			baseConfigurationReference = 7B659FE4BD4E7F552547EF4F /* Pods-IAR-TargetSDK-SampleTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -913,7 +913,7 @@
 		};
 		48938F4727651B9C00D0438A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CBB95C0F02807E2717F17EA5 /* Pods-IAR-TargetSDK-SampleUITests.debug.xcconfig */;
+			baseConfigurationReference = 6063A0610E9241BDE18F1CEB /* Pods-IAR-TargetSDK-SampleUITests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
@@ -937,7 +937,7 @@
 		};
 		48938F4827651B9C00D0438A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8E93DA229ABF4847C2593E68 /* Pods-IAR-TargetSDK-SampleUITests.release.xcconfig */;
+			baseConfigurationReference = 9CDC1B37E332E830552FD51D /* Pods-IAR-TargetSDK-SampleUITests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;


### PR DESCRIPTION
Overview

- Add Location command as a custom command for debug tools

Resources

- IAR-5354

Testing Instructions

- Open the Debug tool, enable simulated location, add a value and see if it's the same when opening Location Markers