### PR TITLE
IAR-5466 Fix the navigation bar hiding after the keyboard appears. 

### DIFF
--- a/IAR-CoreSDK-Sample/IAR-CoreSDK-Sample/ViewControllers/MainViewController.swift
+++ b/IAR-CoreSDK-Sample/IAR-CoreSDK-Sample/ViewControllers/MainViewController.swift
@@ -32,6 +32,7 @@ class MainViewController: UIViewController {
         
         setupView()
         setupLicense()
+        setupKeyboardBehaviour()
     }
 
     
@@ -87,6 +88,24 @@ class MainViewController: UIViewController {
                 FileLogger.shared.log(content: "New User ID: \(userId)")
             }
         }
+    }
+    
+    // MARK: - Keyboard
+    
+    // Hides navigation bar when the keyboard appears in any view that has a navigation Controller
+    // This is not required to integrate the IAR-SDK.
+    // Useful for the Debug Tools View to follow the established constraints
+    private func setupKeyboardBehaviour() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc func keyboardWillShow(notification: NSNotification) {
+        self.navigationController?.isNavigationBarHidden = true
+    }
+    
+    @objc func keyboardWillHide(notification: NSNotification) {
+        self.navigationController?.isNavigationBarHidden = false
     }
 }
 
@@ -147,20 +166,3 @@ extension MainViewController: UITableViewDataSource {
     }
 }
 
-// A small extension to make the navigation bar hide when keyboard appears
-extension IARDebugViewController {
-    
-    override public func viewDidAppear(_ animated: Bool) {
-        self.navigationController?.hidesBarsWhenKeyboardAppears = true
-        super.viewDidAppear(animated)
-    }
-    
-    @objc func keyboardWillHide(notification: NSNotification) {
-        self.navigationController?.isNavigationBarHidden = false
-    }
-    
-    public override func viewDidDisappear(_ animated: Bool) {
-        self.navigationController?.hidesBarsWhenKeyboardAppears = false
-        super.viewDidDisappear(animated)
-    }
-}

--- a/IAR-SurfaceSDK-Sample/IAR-SurfaceSDK-Sample/ViewController/MainViewController.swift
+++ b/IAR-SurfaceSDK-Sample/IAR-SurfaceSDK-Sample/ViewController/MainViewController.swift
@@ -30,6 +30,7 @@ class MainViewController: UIViewController {
         
         setupViews()
         setupLicense()
+        setupKeyboardBehaviour()
     }
     
     
@@ -87,6 +88,25 @@ class MainViewController: UIViewController {
             }
         }
     }
+    
+    // MARK: - Keyboard
+    
+    // Hides navigation bar when the keyboard appears in any view that has a navigation Controller
+    // This is not required to integrate the IAR-SDK.
+    // Useful for the Debug Tools View to follow the established constraints
+    private func setupKeyboardBehaviour() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc func keyboardWillShow(notification: NSNotification) {
+        self.navigationController?.isNavigationBarHidden = true
+    }
+    
+    @objc func keyboardWillHide(notification: NSNotification) {
+        self.navigationController?.isNavigationBarHidden = false
+    }
+    
 }
 
 // MARK: - Extensions
@@ -142,17 +162,5 @@ extension MainViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         section == 0 ? self.sectionHeight : 0
-    }
-}
-
-// A small extension to make the navigation bar hide when keyboard appears
-extension IARDebugViewController {
-    
-    override public func viewDidAppear(_ animated: Bool) {
-        self.navigationController?.hidesBarsWhenKeyboardAppears = true
-    }
-    
-    @objc func keyboardWillHide(notification: NSNotification) {
-        self.navigationController?.isNavigationBarHidden = false
     }
 }

--- a/IAR-TargetSDK-Sample/IAR-TargetSDK-Sample/SupportingFiles/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/IAR-TargetSDK-Sample/IAR-TargetSDK-Sample/SupportingFiles/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,128 +1,122 @@
 {
-    "images":[
-        {
-            "idiom":"iphone",
-            "size":"20x20",
-            "scale":"2x",
-            "filename":"Icon-App-20x20@2x.png"
-        },
-        {
-            "idiom":"iphone",
-            "size":"20x20",
-            "scale":"3x",
-            "filename":"Icon-App-20x20@3x.png"
-        },
-        {
-            "idiom":"iphone",
-            "size":"29x29",
-            "scale":"1x",
-            "filename":"Icon-App-29x29@1x.png"
-        },
-        {
-            "idiom":"iphone",
-            "size":"29x29",
-            "scale":"2x",
-            "filename":"Icon-App-29x29@2x.png"
-        },
-        {
-            "idiom":"iphone",
-            "size":"29x29",
-            "scale":"3x",
-            "filename":"Icon-App-29x29@3x.png"
-        },
-        {
-            "idiom":"iphone",
-            "size":"40x40",
-            "scale":"2x",
-            "filename":"Icon-App-40x40@2x.png"
-        },
-        {
-            "idiom":"iphone",
-            "size":"40x40",
-            "scale":"3x",
-            "filename":"Icon-App-40x40@3x.png"
-        },
-        {
-            "idiom":"iphone",
-            "size":"60x60",
-            "scale":"2x",
-            "filename":"Icon-App-60x60@2x.png"
-        },
-        {
-            "idiom":"iphone",
-            "size":"60x60",
-            "scale":"3x",
-            "filename":"Icon-App-60x60@3x.png"
-        },
-        {
-            "idiom":"iphone",
-            "size":"76x76",
-            "scale":"2x",
-            "filename":"Icon-App-76x76@2x.png"
-        },
-        {
-            "idiom":"ipad",
-            "size":"20x20",
-            "scale":"1x",
-            "filename":"Icon-App-20x20@1x.png"
-        },
-        {
-            "idiom":"ipad",
-            "size":"20x20",
-            "scale":"2x",
-            "filename":"Icon-App-20x20@2x.png"
-        },
-        {
-            "idiom":"ipad",
-            "size":"29x29",
-            "scale":"1x",
-            "filename":"Icon-App-29x29@1x.png"
-        },
-        {
-            "idiom":"ipad",
-            "size":"29x29",
-            "scale":"2x",
-            "filename":"Icon-App-29x29@2x.png"
-        },
-        {
-            "idiom":"ipad",
-            "size":"40x40",
-            "scale":"1x",
-            "filename":"Icon-App-40x40@1x.png"
-        },
-        {
-            "idiom":"ipad",
-            "size":"40x40",
-            "scale":"2x",
-            "filename":"Icon-App-40x40@2x.png"
-        },
-        {
-            "idiom":"ipad",
-            "size":"76x76",
-            "scale":"1x",
-            "filename":"Icon-App-76x76@1x.png"
-        },
-        {
-            "idiom":"ipad",
-            "size":"76x76",
-            "scale":"2x",
-            "filename":"Icon-App-76x76@2x.png"
-        },
-        {
-            "idiom":"ipad",
-            "size":"83.5x83.5",
-            "scale":"2x",
-            "filename":"Icon-App-83.5x83.5@2x.png"
-        },
-        {
-          "size" : "1024x1024",
-          "idiom" : "ios-marketing",
-          "scale" : "1x",
-          "filename" : "ItunesArtwork@2x.png"
-        }
-    ],
-    "info":{
-        "version":1,
-        "author":"makeappicon"
+  "images" : [
+    {
+      "filename" : "Icon-App-20x20@2x.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "filename" : "Icon-App-20x20@3x.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "filename" : "Icon-App-29x29@1x.png",
+      "idiom" : "iphone",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "Icon-App-29x29@2x.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "Icon-App-29x29@3x.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "Icon-App-40x40@2x.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "Icon-App-40x40@3x.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "Icon-App-60x60@2x.png",
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "filename" : "Icon-App-60x60@3x.png",
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "filename" : "Icon-App-20x20@1x.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "filename" : "Icon-App-20x20@2x.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "filename" : "Icon-App-29x29@1x.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "Icon-App-29x29@2x.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "filename" : "Icon-App-40x40@1x.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "Icon-App-40x40@2x.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "filename" : "Icon-App-76x76@1x.png",
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "filename" : "Icon-App-76x76@2x.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "filename" : "Icon-App-83.5x83.5@2x.png",
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "filename" : "ItunesArtwork@2x.png",
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
 }

--- a/IAR-TargetSDK-Sample/IAR-TargetSDK-Sample/ViewControllers/MainViewController.swift
+++ b/IAR-TargetSDK-Sample/IAR-TargetSDK-Sample/ViewControllers/MainViewController.swift
@@ -30,6 +30,7 @@ class MainViewController: UIViewController {
         
         setupViews()
         setupLicense()
+        setupKeyboardBehaviour()
     }
     
     
@@ -86,6 +87,25 @@ class MainViewController: UIViewController {
             }
         }
     }
+    
+    
+    // MARK: - Keyboard
+    
+    // Hides navigation bar when the keyboard appears in any view that has a navigation Controller
+    // This is not required to integrate the IAR-SDK.
+    // Useful for the Debug Tools View to follow the established constraints
+    private func setupKeyboardBehaviour() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+    
+    @objc func keyboardWillShow(notification: NSNotification) {
+        self.navigationController?.isNavigationBarHidden = true
+    }
+    
+    @objc func keyboardWillHide(notification: NSNotification) {
+        self.navigationController?.isNavigationBarHidden = false
+    }
 }
 
 // MARK: - Extensions
@@ -134,16 +154,3 @@ extension MainViewController: UITableViewDataSource {
         section == 0 ? self.sectionHeight : 0
     }
 }
-
-// A small extension to make the navigation bar hide when keyboard appears
-extension IARDebugViewController {
-    
-    override public func viewDidAppear(_ animated: Bool) {
-        self.navigationController?.hidesBarsWhenKeyboardAppears = true
-    }
-    
-    @objc func keyboardWillHide(notification: NSNotification) {
-        self.navigationController?.isNavigationBarHidden = false
-    }
-}
-


### PR DESCRIPTION
### Overview

- Fix navigation bar hiding.

### Resources

IAR-5466

### Testing Instructions

1 - Open debug tools
2 - Show the keyboard selecting the coordinates text field.
3 - Dismiss the keyboard and go back to the main screen
4 - Open another view and select any text field.
RESULT: The navigation bar should hide while it has the keyboard open and show again after the keyboard is dismissed.